### PR TITLE
Project screen minor issues

### DIFF
--- a/src/components/commons/Image/index.js
+++ b/src/components/commons/Image/index.js
@@ -4,9 +4,10 @@ import { propToStyle } from '../../../theme/utils/propToStyle';
 export const Image = styled.img`
   width: auto;
 
-  ${({ bordered }) => bordered && css`
-    border: 1px solid ${({ theme }) => theme.mainUi.background.light.tertiary};
+  ${({ shadowed }) => shadowed && css`
+    /* border: 1px solid ${({ theme }) => theme.mainUi.background.light.tertiary}; */
     border-radius: 8px;
+    box-shadow: 0 4px 8px 0 #5129199e, 0 6px 20px 0 #51291952;
   `}
 
   ${propToStyle('height')};

--- a/src/components/foundation/layout/Grid/index.js
+++ b/src/components/foundation/layout/Grid/index.js
@@ -111,6 +111,7 @@ const Row = styled.div`
   width: 100%;
 
   ${propToStyle('width')}
+  ${propToStyle('maxWidth')}
   ${propToStyle('order')}
   ${propToStyle('flex')}
   ${propToStyle('justifyContent')}

--- a/src/components/screens/ProjectScreen/index.js
+++ b/src/components/screens/ProjectScreen/index.js
@@ -12,6 +12,22 @@ import Text from '../../foundation/Text';
 import imagesArr from '../../../../db.json';
 import { Image } from '../../commons/Image';
 
+function RepoInfo({ children }) {
+  return (
+    <Grid.Col
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+    >
+      {children}
+    </Grid.Col>
+  );
+}
+
+RepoInfo.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
 export default function ProjectScreen({
   name,
   description,
@@ -61,45 +77,31 @@ export default function ProjectScreen({
           justifyContent="center"
         >
           <Grid.Row
-            width={{
-              xs: '100%',
-              sm: '80%',
-              md: '60%',
-              lg: '40%',
-            }}
+            // width={{
+            //   xs: '100%',
+            //   sm: '80%',
+            //   md: '60%',
+            //   lg: '40%',
+            // }}
+            width="auto"
+            maxWidth="350px"
           >
-            <Grid.Col
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-            >
+            <RepoInfo>
               <RepoForked size={16} style={{ marginRight: '8px' }} alt="Forks" />
               {`${forks} `}
-            </Grid.Col>
-            <Grid.Col
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-            >
+            </RepoInfo>
+            <RepoInfo>
               <IssueOpened size={16} style={{ marginRight: '8px' }} alt="Issues abertas" />
               {`${openIssues} `}
-            </Grid.Col>
-            <Grid.Col
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-            >
+            </RepoInfo>
+            <RepoInfo>
               <Eye size={16} style={{ marginRight: '8px' }} alt="Watchers" />
               {`${watchers} `}
-            </Grid.Col>
-            <Grid.Col
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-            >
+            </RepoInfo>
+            <RepoInfo>
               <StarFill size={16} style={{ marginRight: '8px' }} alt="Stars" />
               {`${stars} `}
-            </Grid.Col>
+            </RepoInfo>
           </Grid.Row>
         </Grid.Col>
       </Grid.Row>
@@ -128,7 +130,7 @@ export default function ProjectScreen({
             src={image.path}
             alt={image.description}
             height={{ xs: '180px', sm: '220px', md: '300px' }}
-            bordered
+            shadowed
           />
         </Grid.Col>
       </Grid.Row>


### PR DESCRIPTION
- Adiciona box-shadow às imagens de projeto, em substituição à borda marrom (fix #37)
- Cria o componente RepoInfo para abrigar as colunas com informações do repositório (issues, stars etc.)
- Deixa a Row com as informações com tamanho automático para se adequar ao tamanho do RepoInfo, mas chegando no máximo a 350px